### PR TITLE
feat: dont throw error on no posts

### DIFF
--- a/src/server/routers/post-router.ts
+++ b/src/server/routers/post-router.ts
@@ -12,12 +12,6 @@ export const postRouter = router({
       cache: { id: "recent-post" },
     })
 
-    if (!recentPost) {
-      throw new HTTPException(404, {
-        message: "No post found",
-      })
-    }
-
     return c.superjson(recentPost)
   }),
 


### PR DESCRIPTION
Currently this throws an error and a post needs to be added in neon, this pull request will remove throwing that error.

Other fix might be showcasing how to handle errors thrown in the endpoint and handle on the frontend but went with the first option.

Looking forward to using this stack! Thanks!