### PR TITLE
fix: update pgTable third parameter to accept array instead of object

### DIFF
--- a/cli/template/extras/src/server/db/schema/with-mysql.ts
+++ b/cli/template/extras/src/server/db/schema/with-mysql.ts
@@ -8,7 +8,7 @@ export const posts = mysqlTable(
     createdAt: timestamp("createdAt").defaultNow().notNull(),
     updatedAt: timestamp("updatedAt").defaultNow().notNull(),
   },
-  (table) => ({
-    nameIdx: index("Post_name_idx").on(table.name),
-  })
+  (table) => [
+    index("Post_name_idx").on(table.name)
+  ]
 )

--- a/cli/template/extras/src/server/db/schema/with-postgres.ts
+++ b/cli/template/extras/src/server/db/schema/with-postgres.ts
@@ -8,7 +8,7 @@ export const posts = pgTable(
     createdAt: timestamp("createdAt").defaultNow().notNull(),
     updatedAt: timestamp("updatedAt").defaultNow().notNull(),
   },
-  (table) => ({
-    nameIdx: index("Post_name_idx").on(table.name),
-  })
+  (table) => [
+    index("Post_name_idx").on(table.name)
+  ]
 )


### PR DESCRIPTION
## Summary

This pull request updates the `pgTable` function to use an array for its third parameter, replacing the previous object-based approach. This change is necessary due to the deprecation of the old API and the introduction of a new API that requires an array.

## Changes

- Updated the `pgTable` function calls to use an array for the third parameter.

### Deprecated Version

```javascript
export const users = pgTable("users", {
    id: integer(),
}, (t) => ({
    idx: index('custom_name').on(t.id)
}));
```

### New API
```javascript
export const users = pgTable("users", {
    id: integer(),
}, (t) => [
    index('custom_name').on(t.id)
]);
```