### PR TITLE
fix: add Content-Type to default cors allowHeaders

### DIFF
--- a/packages/jstack/src/server/j.ts
+++ b/packages/jstack/src/server/j.ts
@@ -68,13 +68,13 @@ class JStack {
          * CORS middleware configuration with default settings for API endpoints.
          *
          * @default
-         * - Allows 'x-is-superjson' in headers
+         * - Allows 'x-is-superjson' and 'Content-Type' in headers
          * - Exposes 'x-is-superjson' in headers
          * - Accepts all origins
          * - Enables credentials
          */
         cors: cors({
-          allowHeaders: ["x-is-superjson"],
+          allowHeaders: ["x-is-superjson", "Content-Type"],
           exposeHeaders: ["x-is-superjson"],
           origin: (origin) => origin,
           credentials: true,


### PR DESCRIPTION

This PR fixes the following fetch error `Access to fetch at 'http://localhost:8080/api/post/create' from origin 'http://localhost:3000' has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.` by adding "Content-Type" to `j.defaults.cors` allow headers list.