### PR TITLE
fix: add missing return in auth middleware docs

### DIFF
--- a/www/src/docs/backend/middleware.mdx
+++ b/www/src/docs/backend/middleware.mdx
@@ -50,7 +50,7 @@ const authMiddleware = j.middleware(async ({ c, next }) => {
   }
 
   // 👇 Attach user to `ctx` object
-  await next({ user: { name: "John Doe" } })
+  return await next({ user: { name: "John Doe" } })
 })
 
 /**


### PR DESCRIPTION
spent way too long trying to figure out why my procedures had no context lol