### PR TITLE
fix: Socket events sent handled twice

### DIFF
--- a/packages/jstack-shared/src/socket.ts
+++ b/packages/jstack-shared/src/socket.ts
@@ -45,26 +45,6 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 
     this.ws = ws
     this.emitter = new EventEmitter(ws, { incomingSchema, outgoingSchema })
-
-    this.ws.addEventListener("message", (event) => {
-      try {
-        const data = z.string().parse(event.data)
-        const eventSchema = z.tuple([z.string(), z.unknown()])
-
-        const parsedData = JSON.parse(data)
-
-        const [eventName, eventData] = eventSchema.parse(parsedData)
-
-        if (eventName === "ping") {
-          this.ws.send(JSON.stringify(["pong", null]))
-          return
-        }
-
-        this.emitter.handleEvent(eventName, eventData)
-      } catch (err) {
-        logger.error(`Unable to handle event "${event.data}":`, err)
-      }
-    })
   }
 
   get rooms() {


### PR DESCRIPTION
Fixes issue #62 

Modifications:
- Remove `addEventListener('message')` call from `ServerSocket` constructor
- Use `onclose`, `onerror` and `onmessage` attributes instead of calling `addEventListener`in router `setupRoutes` method for `ws` type.